### PR TITLE
Fix README for missing NEXT_PUBLIC_BASE_URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,4 @@
 # https://app.supabase.com/project/_/settings/api
 NEXT_PUBLIC_SUPABASE_URL=your-project-url
 NEXT_PUBLIC_SUPABASE_PUBLISHABLE_OR_ANON_KEY=your-anon-key
+NEXT_PUBLIC_BASE_URL=your-domain.com

--- a/README.md
+++ b/README.md
@@ -61,7 +61,11 @@
    ```dotenv
    NEXT_PUBLIC_SUPABASE_URL=<Your Supabase URL>
    NEXT_PUBLIC_SUPABASE_PUBLISHABLE_OR_ANON_KEY=<Your publishable/anon key>
+   NEXT_PUBLIC_BASE_URL=<your-domain.com>
    ```
+
+   `NEXT_PUBLIC_BASE_URL` はメタデータ生成に使われるアプリのベースURLです。
+   何も設定しなくても `http://localhost:3000` が使われるので、開発中はそのままで大丈夫です。
 
 4. **依存パッケージをインストール**
 


### PR DESCRIPTION
## Summary
- document NEXT_PUBLIC_BASE_URL in the setup instructions
- add placeholder to `.env.example`
- lighten the wording of the explanation

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68847e00e8e4832ebc5299f425dd2627